### PR TITLE
Rewrite Analysis.toString()

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ The Java Thread Dump Analyzer is licensed under
 the copyright belongs to Spotify AB.
 
 ## TODO
+* List top RUNNING methods before everything else. I have a thread
+  dump taken on a system that was swapping basically getting the GC
+  stuck. With a list of top RUNNING methods it should be possible to
+  see this from the analysis.
+
 * Make the Thread class parse held locks, waited-for locks and
 waited-for condition variables from the thread dump.
 

--- a/analyze.js
+++ b/analyze.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 /* global document */
 
-var EMPTY_STACK = "	<empty stack>\n";
+var EMPTY_STACK = "	<empty stack>";
 
 // This method is called from HTML so we need to tell JSHint it's not unused
 function analyzeTextfield() { // jshint ignore: line
@@ -86,22 +86,16 @@ function Thread(line) {
         if (line.match(FRAME) === null) {
             return false;
         }
-        this._frames.push(line);
+        this.frames.push(line);
         return true;
     };
 
     this.toStackString = function() {
-        var string = "";
-        for (var i = 0; i < this._frames.length; i++) {
-            var frame = this._frames[i];
-            string += frame + '\n';
-        }
-
-        if (string === '') {
+        if (this.frames.length === 0) {
             return EMPTY_STACK;
         }
 
-        return string;
+        return this.frames.join('\n');
     };
 
     this.toHeaderString = function() {
@@ -156,7 +150,7 @@ function Thread(line) {
         return undefined;
     }
 
-    this._frames = [];
+    this.frames = [];
 }
 
 function StringCounter() {
@@ -320,6 +314,7 @@ function Analyzer(text) {
             for (var k = 0; k < stackFrames.length; k++) {
                 asString += stackFrames[k] + "\n";
             }
+            asString += '\n';
         }
 
         return asString;

--- a/analyze.js
+++ b/analyze.js
@@ -281,6 +281,19 @@ function Analyzer(text) {
         for (var j = 0; j < stacks.length; j++) {
             var currentStack = stacks[j];
             var threads = stacksToThreads[currentStack];
+
+            threads.sort(function(a, b){
+                var aHeader = a.toHeaderString();
+                var bHeader = b.toHeaderString();
+                if (aHeader > bHeader) {
+                    return 1;
+                }
+                if (aHeader < bHeader) {
+                    return -1;
+                }
+                return 0;
+            });
+
             threadsAndStacks.push({
                 threads: threads,
                 stackFrames: currentStack.split('\n')
@@ -306,12 +319,9 @@ function Analyzer(text) {
                 asString += "" + threads.length + " threads with this stack:\n";
             }
 
-            var headers = [];
             for (var j = 0; j < threads.length; j++) {
-                headers.push(threads[j].toHeaderString());
+                asString += threads[j].toHeaderString() + '\n';
             }
-            headers.sort();
-            asString += headers.join('\n') + '\n';
 
             for (var k = 0; k < stackFrames.length; k++) {
                 asString += stackFrames[k] + "\n";

--- a/analyze.js
+++ b/analyze.js
@@ -294,11 +294,13 @@ function Analyzer(text) {
         var threadsAndStacks = this._toThreadsAndStacks();
 
         var asString = "";
-        asString += "" + this.threads.length + " threads found:\n\n";
+        asString += "" + this.threads.length + " threads found:\n";
         for (var i = 0; i < threadsAndStacks.length; i++) {
             var currentThreadsAndStack = threadsAndStacks[i];
             var stackFrames = currentThreadsAndStack.stackFrames;
             var threads = currentThreadsAndStack.threads;
+
+            asString += '\n';
 
             if (threads.length > 4) {
                 asString += "" + threads.length + " threads with this stack:\n";
@@ -314,7 +316,6 @@ function Analyzer(text) {
             for (var k = 0; k < stackFrames.length; k++) {
                 asString += stackFrames[k] + "\n";
             }
-            asString += '\n';
         }
 
         return asString;

--- a/tests.js
+++ b/tests.js
@@ -96,12 +96,13 @@ QUnit.test( "multiline thread name", function(assert) {
 
     // Test the Analyzer's toString() method as well now that we have an Analyzer
     var analysisLines = analyzer.toString().split('\n');
-    assert.equal(analysisLines.length, 5);
-    assert.equal(analysisLines[0], "1 threads found:");
-    assert.equal(analysisLines[1], "");
-    assert.equal(analysisLines[2], '"line 1, line 2": runnable');
-    assert.equal(analysisLines[3], '	<empty stack>');
-    assert.equal(analysisLines[4], "");
+    assert.equal(analysisLines, [
+        "1 threads found:",
+        "",
+        '"line 1, line 2": runnable',
+        "	<empty stack>",
+        ""
+    ]);
 });
 
 QUnit.test( "thread stack", function(assert) {

--- a/tests.js
+++ b/tests.js
@@ -137,6 +137,7 @@ QUnit.test( "analyze single thread", function(assert) {
 });
 
 QUnit.test( "analyze two threads with same stack", function(assert) {
+    // Thread dump with zebra before aardvark
     var threadDump = [
         '"zebra thread" prio=10 tid=0x00007f16a118e000 nid=0x6e5a runnable [0x00007f18b91d0000]',
         '	at fluff',
@@ -154,9 +155,9 @@ QUnit.test( "analyze two threads with same stack", function(assert) {
     var aardvark = threads[1];
     assert.equal(aardvark.name, "aardvark thread");
 
-    // This test validates that threads with the same stack are sorted by name
     var analysisResult = analyzer._toThreadsAndStacks();
     assert.deepEqual(analysisResult, [{
+        // Make sure the aardvark comes before the zebra
         threads: [aardvark, zebra],
         stackFrames: ["	at fluff"]
     }]);

--- a/tests.js
+++ b/tests.js
@@ -89,10 +89,11 @@ QUnit.test( "multiline thread name", function(assert) {
 
     assert.equal(threads.length, 1);
     var threadLines = threads[0].toString().split('\n');
-    assert.equal(threadLines.length, 3);
-    assert.equal(threadLines[0], '"line 1, line 2": runnable');
-    assert.equal(threadLines[1], '	<empty stack>');
-    assert.equal(threadLines[2], '');
+    assert.equal(threadLines, [
+        '"line 1, line 2": runnable',
+        '	<empty stack>',
+        ''
+    ]);
 
     // Test the Analyzer's toString() method as well now that we have an Analyzer
     var analysisLines = analyzer.toString().split('\n');

--- a/tests.js
+++ b/tests.js
@@ -136,6 +136,32 @@ QUnit.test( "analyze single thread", function(assert) {
     }]);
 });
 
+QUnit.test( "analyze two threads with same stack", function(assert) {
+    var threadDump = [
+        '"zebra thread" prio=10 tid=0x00007f16a118e000 nid=0x6e5a runnable [0x00007f18b91d0000]',
+        '	at fluff',
+        "",
+        '"aardvark thread" prio=10 tid=0x00007f16a118e000 nid=0x6e5a runnable [0x00007f18b91d0000]',
+        '	at fluff'
+    ].join('\n');
+
+    var analyzer = new Analyzer(threadDump);
+
+    var threads = analyzer.threads;
+    assert.equal(threads.length, 2);
+    var zebra = threads[0];
+    assert.equal(zebra.name, "zebra thread");
+    var aardvark = threads[1];
+    assert.equal(aardvark.name, "aardvark thread");
+
+    // This test validates that threads with the same stack are sorted by name
+    var analysisResult = analyzer._toThreadsAndStacks();
+    assert.deepEqual(analysisResult, [{
+        threads: [aardvark, zebra],
+        stackFrames: ["	at fluff"]
+    }]);
+});
+
 QUnit.test( "thread stack", function(assert) {
     var header = '"Thread name" prio=10 tid=0x00007f1728056000 nid=0x1347 sleeping[0x00007f169cdcb000]';
     var thread = new Thread(header);

--- a/tests.js
+++ b/tests.js
@@ -134,10 +134,10 @@ QUnit.test( "full dump analysis", function(assert) {
     var input = document.getElementById("sample-input").innerHTML;
     var expectedOutput = unescapeHtml(document.getElementById("sample-analysis").innerHTML);
     var analyzer = new Analyzer(input);
-    assert.equal(analyzer.toString(), expectedOutput);
+    assert.equal(analyzer.toString().split('\n'), expectedOutput.split('\n'));
 
     var expectedIgnores = document.getElementById("sample-ignored").innerHTML;
-    assert.equal(analyzer.toIgnoresString(), expectedIgnores);
+    assert.equal(analyzer.toIgnoresString().split('\n'), expectedIgnores.split('\n'));
 });
 
 QUnit.test("extract regex from string", function(assert) {


### PR DESCRIPTION
Move logic into another method and make Analysis.toString() just render the result of that method.

This is in preparation for turning the threads list into proper HTML from <pre>.
