### PR TITLE
Fix parser for remote thread dumps

### DIFF
--- a/analyze.js
+++ b/analyze.js
@@ -315,6 +315,12 @@ function Thread(line) {
     this.tid = match.value;
     line = match.shorterString;
 
+    if(this.tid === undefined){
+        match = _extract(/ - Thread t@([0-9a-fx]+)/,line)
+        this.tid = match.value
+        line = match.shorterString
+    }
+
     match = _extract(/ prio=([0-9]+)/, line);
     this.prio = match.value;
     line = match.shorterString;
@@ -589,7 +595,7 @@ function Analyzer(text) {
         var lines = text.split('\n');
         for (var i = 0; i < lines.length; i++) {
             var line = lines[i];
-            while (line.charAt(0) === '"' && line.indexOf('prio=') === -1) {
+            while (line.charAt(0) === '"' && line.indexOf('prio=') === -1 && line.indexOf('t@') === -1) {
                 // Multi line thread name
                 i++;
                 if (i >= lines.length) {

--- a/analyze.js
+++ b/analyze.js
@@ -316,9 +316,9 @@ function Thread(line) {
     line = match.shorterString;
 
     if(this.tid === undefined){
-        match = _extract(/ - Thread t@([0-9a-fx]+)/,line)
-        this.tid = match.value
-        line = match.shorterString
+        match = _extract(/ - Thread t@([0-9a-fx]+)/,line);
+        this.tid = match.value;
+        line = match.shorterString;
     }
 
     match = _extract(/ prio=([0-9]+)/, line);

--- a/tests.js
+++ b/tests.js
@@ -124,6 +124,13 @@ QUnit.test( "thread header 13", function(assert) {
     assert.equal(new Thread(header).group, undefined);
 });
 
+QUnit.test("thread header 14", function(assert){
+    var header = '"http-bio-8810-exec-147" - Thread t@96965';
+    assert.equal(new Thread(header).name,'http-bio-8810-exec-147');
+    assert.equal(new Thread(header).tid, '96965');
+    assert.equal(new Thread(header).group, undefined);
+});
+
 // A thread should be considered running if it has a stack trace and
 // is RUNNABLE
 QUnit.test("thread.running", function(assert) {
@@ -308,6 +315,37 @@ QUnit.test( "analyze thread waiting for traditional lock", function(assert) {
     assert.deepEqual(thread.locksHeld, locksHeld);
 
     assert.equal(thread.synchronizerClasses['0xe0375410'], 'beans.ConnectionPool');
+    assert.equal(thread.synchronizerClasses['47114712gris'], null);
+});
+
+QUnit.test(" analyze thread waiting for locks 2", function(assert){
+    var threadDump= [
+        '"http-5525-116" - Thread t@151',
+        '   java.lang.Thread.State: BLOCKED',
+        '   at org.apache.log4j.Category.callAppenders(Category.java:205)',
+        '   - waiting to lock <259a4a41> (a org.apache.log4j.spi.RootLogger) owned by "http-5525-127" t@162',
+        '   at org.apache.log4j.Category.forcedLog(Category.java:391)',
+        '   at org.apache.log4j.Category.log(Category.java:856)',
+        '   at org.apache.juli.logging.impl.Log4JLogger.error(Log4JLogger.java:251)',
+        '   at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:274)',
+        '   at java.lang.Thread.run(Thread.java:662)',
+        '',
+        '   Locked ownable synchronizers:',
+        '   - None',
+    ].join('\n');
+
+    var analyzer = new Analyzer(threadDump);
+    var threads = analyzer.threads;
+    assert.equal(threads.length, 1);
+    var thread = threads[0];
+
+    assert.equal(thread.wantNotificationOn, null);
+    assert.equal(thread.wantToAcquire, '259a4a41');
+
+    var locksHeld = [ /* None */ ];
+    assert.deepEqual(thread.locksHeld, locksHeld);
+
+    assert.equal(thread.synchronizerClasses['259a4a41'], 'org.apache.log4j.spi.RootLogger');
     assert.equal(thread.synchronizerClasses['47114712gris'], null);
 });
 


### PR DESCRIPTION
fixes #7 

A threads header string is different when it is taken remotely via jvisual vm. Specifically the metadata info that follows a thread name is missing. Such as

```
daemon prio=5 os_prio=31 tid=0x00007fc1dc06e000 nid=0x5b03 runnable [0x00000001266ee000]
```

Instead the thread is only given a simple thread id in the form 't@X' where X is  a hex number. Example

```
- Thread t@151
```

This PR fixes the parser to check for both header styles
